### PR TITLE
Document seat cooler select entities for Teslemetry

### DIFF
--- a/source/_integrations/teslemetry.markdown
+++ b/source/_integrations/teslemetry.markdown
@@ -128,6 +128,8 @@ These are the entities available in the Teslemetry integration. Not all entities
 |Media player|Media player|Yes|
 |Number|Charge current|Yes|
 |Number|Charge limit|Yes|
+|Select|Seat cooler front left|Yes|
+|Select|Seat cooler front right|Yes|
 |Select|Seat heater front left|Yes|
 |Select|Seat heater front right|Yes|
 |Select|Seat heater rear center|No|


### PR DESCRIPTION
## Proposed change

Adds the two new front seat cooler select entities (`Seat cooler front left`, `Seat cooler front right`) being introduced in [home-assistant/core#175422](https://github.com/home-assistant/core/pull/175422) to the Teslemetry entity table.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/175422
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards